### PR TITLE
refactor/secure-storage

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.flutter_boilerplate"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 31
         versionCode 1
         versionName "1.0.0"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  shared_preferences_ios: aef470a42dc4675a1cdd50e3158b42e3d1232b32
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,20 +1,26 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_secure_storage (3.3.1):
+    - Flutter
   - shared_preferences_ios (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c

--- a/lib/app/di/application_container.dart
+++ b/lib/app/di/application_container.dart
@@ -5,7 +5,7 @@ import 'package:flutter_boilerplate/app/domain/persistence/credentials_persisten
 import 'package:flutter_boilerplate/app/domain/repositories/authentication_repository.dart';
 import 'package:flutter_boilerplate/app/presentation/viewmodels/authentication/authentication_viewmodel.dart';
 import 'package:flutter_boilerplate/env/env.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 abstract class ApplicationContainer {
   static final Dio client = Dio(BaseOptions(baseUrl: Env.baseUrl))
@@ -16,8 +16,19 @@ abstract class ApplicationContainer {
   static final AuthenticationService authenticationService =
       AuthenticationServiceImpl(client);
 
-  static final CredentialsPersistence credentialsPersistence =
-      CredentialsPersistenceImpl(SharedPreferences.getInstance());
+  static const AndroidOptions secureStorageAndroidOptions =
+      AndroidOptions(encryptedSharedPreferences: true);
+
+  static const IOSOptions secureStorageIOSOptions =
+      IOSOptions(accessibility: IOSAccessibility.first_unlock);
+
+  static const CredentialsPersistence credentialsPersistence =
+      CredentialsPersistenceImpl(
+    FlutterSecureStorage(
+      aOptions: secureStorageAndroidOptions,
+      iOptions: secureStorageIOSOptions,
+    ),
+  );
 
   static final AuthenticationRepository authenticationRepository =
       AuthenticationRepositoryImpl(

--- a/lib/app/domain/constants/secure_storage_constants.dart
+++ b/lib/app/domain/constants/secure_storage_constants.dart
@@ -1,0 +1,3 @@
+abstract class SecureStorageConstants {
+  static const token = '@token:';
+}

--- a/lib/app/domain/constants/shared_preferences.dart
+++ b/lib/app/domain/constants/shared_preferences.dart
@@ -1,3 +1,0 @@
-abstract class SharedPreferencesConstants {
-  static const token = '@token:';
-}

--- a/lib/app/domain/persistence/credentials_persistence.dart
+++ b/lib/app/domain/persistence/credentials_persistence.dart
@@ -1,31 +1,36 @@
-import 'package:flutter_boilerplate/app/domain/constants/shared_preferences.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_boilerplate/app/domain/constants/secure_storage_constants.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 abstract class CredentialsPersistence {
   Future<String?> getCredentials();
-  Future<bool> storeCredentials({required String token});
-  Future<bool> clearCredentials();
+  Future<void> storeCredentials({required String token});
+  Future<void> clearCredentials();
 }
 
 class CredentialsPersistenceImpl implements CredentialsPersistence {
-  const CredentialsPersistenceImpl(this._lazySharedPreferences);
+  const CredentialsPersistenceImpl(this._secureStorage);
 
-  final Future<SharedPreferences> _lazySharedPreferences;
+  final FlutterSecureStorage _secureStorage;
 
   @override
   Future<String?> getCredentials() async {
-    return (await _lazySharedPreferences)
-        .getString(SharedPreferencesConstants.token);
+    return await _secureStorage.read(
+      key: SecureStorageConstants.token,
+    );
   }
 
   @override
-  Future<bool> storeCredentials({required String token}) async {
-    return await (await _lazySharedPreferences)
-        .setString(SharedPreferencesConstants.token, token);
+  Future<void> storeCredentials({required String token}) async {
+    return await _secureStorage.write(
+      key: SecureStorageConstants.token,
+      value: token,
+    );
   }
 
   @override
-  Future<bool> clearCredentials() async {
-    return await (await _lazySharedPreferences).clear();
+  Future<void> clearCredentials() async {
+    return await _secureStorage.delete(
+      key: SecureStorageConstants.token,
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -244,6 +244,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   characters:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.5"
   lints:
     dependency: transitive
     description:
@@ -338,6 +338,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -435,7 +442,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pubspec_parse:
     dependency: transitive
     description:
@@ -449,35 +456,35 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.1.0"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.1.0"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -498,7 +505,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.1.0"
   shelf:
     dependency: transitive
     description:
@@ -580,7 +587,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   timing:
     dependency: transitive
     description:
@@ -622,14 +629,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.1"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   yaml:
     dependency: transitive
     description:
@@ -638,5 +645,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   json_annotation: ^4.4.0
   equatable: ^2.0.3
   envify: ^2.0.2
-  shared_preferences: ^2.0.12
+  shared_preferences: ^2.0.13
   provider: ^6.0.2
 
 dev_dependencies:
@@ -51,7 +51,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^1.0.0
   build_runner: ^2.1.7
-  json_serializable: ^6.1.3
+  json_serializable: ^6.1.5
   envify_generator: ^2.0.2
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   envify: ^2.0.2
   shared_preferences: ^2.0.13
   provider: ^6.0.2
+  flutter_secure_storage: ^5.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**O que foi feito**
- Substitui a lib `SharedPreferences` pela `FlutterSecureStorage` para salvar localmente dados sensíveis (JWT, Refresh Token, etc)
com auxilio de criptografia
- Altera a versão mínima do OS para a SDK 18 (Android 4.3), devido o uso da API `KeyStore` para o Android
- Atualiza demais dependências